### PR TITLE
Fix delete json

### DIFF
--- a/src/Data/Ollama/Delete.hs
+++ b/src/Data/Ollama/Delete.hs
@@ -21,7 +21,16 @@ import Network.HTTP.Types.Status (status404)
 -- TODO: Add Options parameter
 -- TODO: Add Context parameter
 newtype DeleteModelReq = DeleteModelReq {name :: Text}
-  deriving newtype (Show, Eq, ToJSON)
+  deriving newtype (Show, Eq)
+
+instance ToJSON DeleteModelReq where
+  toJSON
+    ( DeleteModelReq
+        name_
+      ) =
+      object
+        [ "name" .= name_
+        ]
 
 
 deleteModel :: Text -> IO ()


### PR DESCRIPTION
Aeson does not encode a newtype as `key: value`

That was encoding the delete just as the name
Explicit instance now does `name: "...."`


The only other newtype like this I see is in Create and that already has an explicit instance. So I think its just this one to be fixed.